### PR TITLE
Added TechWorm to News & Blogs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -987,6 +987,7 @@ premium services
 
 ## Piracy Blogs and News
 - [TorrentFreak](https://torrentfreak.com) :star2: TorrentFreak is a publication dedicated to bringing the latest news about copyright, privacy, and everything related to filesharing.
+- [TechWorm](https://www.techworm.net) Techworm is a Tech, Cyber-security news platform.
 
 ## Content Discovery
 - [Trakt.tv](https://trakt.tv/) :star2: a platform that does many things, but primarily keeps track of TV shows and movies you watch.


### PR DESCRIPTION
Added TechWorm to the news & blogs section as their website has a lot of news and articles about pirating and torrenting for issue #63