### PR TITLE
Remove Games Torrent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -789,7 +789,6 @@ premium services
 - [cream-api-autoinstaller](https://github.com/Douile/cream-api-autoinstaller) A python script to automatically install Cream API for Steam games
 
 ### Repacks
-- [Games Torrent](http://gamestorrent.co/) Torrent site, part of IGG GAMES with releases from CODEX, RELOADED, CPY, SKIDROW, and more
 - [FitGirl Repacks](http://fitgirl-repacks.site/) :star2: Popular DDL and torrent site for game repacks
 - [Xatab Repacks](https://xatab-repack.net) Russian game repacker, primarily torrents
 - [ElAmigos Games](https://www.elamigos-games.com/) Premium links to cracked games


### PR DESCRIPTION
From the closing of GOD, it is pretty clear that IGG cannot be trusted or be promoted. They are clearly in Piracy for money as oppose to other reputable site like fitgirl or GOD (rip). I am confident that IGG will continue with their behavior -- doxing and reporting other piracy sites to eliminate competition. We have to send a clear message, that any site doing these kind of things will have to go down.

Regarding GOD doxxing those Vietnamese guys, that was completely wrong and he shouldn't have done that. However, it seems that IGG was the first one to do the doxxing, according to [fitgirl](https://www.reddit.com/r/CrackWatch/comments/a2co4c/crack_watch_please_do_not_post_dox_information/eazl8ki). Furthermore, IGG doxxing GOD's family was totally disgusting.

p/s: i live just 2 block from those IGG guys,  might give an update should anything happen.