### PR TITLE
Fixed Streaming Category (Maybe?)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,12 @@
     - [Open Directories](#open-directories)
     - [Sports Streaming](#sports-streaming)
     - [Streaming Sites](#streaming-sites)
+        - [HD Streaming](#hd-streaming)
+        - [Big Media Libraries](#big-media-libraries)
+        - [TV & Anime Streaming](#tv-and-anime-streaming)
+        - [Specialty Sites](#specialty-sites)
+        - [Openload Hosts](#openload-hosts)
+        - [Uncategorized](#uncategorized)
 - [Media Centre Applications](#media-centre-applications)
     - [Stremio Addons](#stremio-addons)
 - [Plex](#plex)
@@ -603,10 +609,84 @@ premium services
 - [Panelshow.club](http://panelshow.club/) Directory of panel show TV episodes from [/r/panelshow](https://www.reddit.com/r/panelshow)
 
 ### Streaming Sites
-- [How To Stream Movies, TV, Anime & Sports Online](https://www.reddit.com/r/FREEMEDIAFUCKYEAH/comments/9q11kg/how_to_stream_movies_tv_anime_sports_online/) :star2: Huge list by /u/nbatman
+- [How To Stream Movies, TV, Anime & Sports Online](https://www.removeddit.com/r/FREEMEDIAFUCKYEAH/comments/8fwnxr/how_to_stream_movies_tv_anime_online/) :star2: Huge list by /u/nbatman
+
+#### HD Streaming
+- [HD MultiredditHD](https://www.reddit.com/user/nbatman/m/streaming2/)
 - [StreamCR](https://scr.cr/)
-- [cine.to](https://cine.to/)
+- [HDFlix](http://hdflix.net/)
+- [Yes! Movies](https://yesmovies.to)
+- [HDO](https://hdo.to/)
 - [Solarmovie](https://solarmoviez.ru/solar.html)
+- [FFilms](http://ffilms.org/)
+- [Flixtor](https://flixtor.to/)
+- [Flenix](https://flenix.co/)
+- [Streamlord](http://www.streamlord.com/)
+- [Spacemov](http://spacemov.io/)
+- [XMovies8](https://xmovies8.ru/)
+- [IWatchFlix](https://www.iwatchflix.xyz/)
+- [r/Megalinks](https://www.reddit.com/r/megalinks/)
+- [IceFilms](http://www.icefilms.info/)
+
+#### Big Media Libraries
+- [Streaming Multireddit](https://www.reddit.com/user/nbatman/m/streaming/)
+- [Alluc.uno](https://w1.alluc.uno/)
+- [Ololo](https://ololo.to/)
+- [Viooz](https://vzm.ag/)
+- [5Movies](http://5movies.to/)
+- [2TwoMovies](https://two-movies.net/)
+- [CafeHulu](http://cafehulu.com/)
+- [Solarmovie](http://www.solarmovie.fm/)
+- [Primewire](http://www.primewire.is/)
+- [Afdah](http://afdah.to/)
+- [FreeMoviez](https://freemoviesz/)
+- [Solarmovies](https://solamovies.cc/)
+- [Youtube](http://youtube.com/)
+
+#### TV and Anime Streaming
+- [TVRaven](https://www.onetvraven.pro/)
+- [WatchSeries](http://dwatchseries.to/)
+- [WatchSeries 2.0](https://watch-series.io/)
+- [TVBox](https://tvbox.ag/)
+- [PutlockerSeries](http://putlockerseries.to/)
+- [480mkv](http://480mkv.com/)
+- [KimCartoon](https://kimcartoon.co/)
+- [WatchCartoon](https://www.watchcartoononline.io/)
+- [9Anime](https://www4.9anime.is/)
+- [Kissanime.ru](http://kissanime.ru/) or [Kissanime.ac](https://kissanime.ac/)
+- [MioMio](http://www.miomio.tv/)
+- [Anime8](https://anime8.me/)
+- [NineAnime](https://www.nineanime.com/)
+
+#### Specialty Sites
+- [Einthusan](https://einthusan.tv/intro/) (Foreign)
+- [Dramago](http://www.dramago.com/)
+- [WatchAsian](https://www2.watchasian.co/) (Foreign)
+- [Layarkaca](http://layarkaca21.ru/) (Foreign)
+- [DramaCool](http://www1.dramacoolfirst.com/) (Foreign)
+- [KingsofHorror](https://www.youtube.com/user/TheKingsofHorror/) (Youtube Horror)
+- [MutantSorority](https://www.youtube.com/channel/UCWcF6KTn_sSSJ1AIj1bQmRg) (Youtube Horror)
+- [TromaMovies](https://www.youtube.com/channel/UC4O0LNYmaOczcSMHA_FE1Mw) (Youtube Horror)
+- [Film1k](http://www.film1k.com/la-bestia-uccide-a-sangue-freddo-1971.html) (Movies with nudity)
+- [Rulu](https://www.rulu.co/) (Youtube Red Series)
+- [Club MST3k](http://www.club-mst3k.com/) (Every episode of MST3K)
+- [Archive.org](https://archive.org/) (Old movies)
+
+#### Openload Hosts
+- [Ololo](https://ololo.to/)
+- [MovieZion](https://www.nicemoviezion.pro/)
+- [FMovies](https://www4.fmovies.se/)
+- [Vmovee](https://vmovee.me/)
+- [MovieJagg](https://www.coolmoviejagg.pro/)
+- [IWannaWatch](https://www.iwannawatch.is/)
+- [Solarmoviefreez](http://solarmoviefreez.com/)
+- [UWatchFree](https://www.uwatchfree.tv/)
+- [Oakmovies](http://oakmovies.com/)
+- [Vexmovies](http://vexmovies.org/)
+- [Openloadmovie](https://openloadmovie.ws/)
+
+#### Uncategorized
+- [cine.to](https://cine.to/)
 - [Movie123](http://movie123.club/)
 - [FlixGo](https://flixgo.net/)
 - [LookMovie](https://lookmovie.ag/)
@@ -622,7 +702,6 @@ premium services
 - [HDEUROPIX](https://topeuropix.net/)
 - [/r/MovieStreamingSites](https://www.reddit.com/r/MovieStreamingSites/)
 - [/r/BestOfStreamingVideo](https://www.reddit.com/r/BestOfStreamingVideo/)
-- [Yes! Movies](https://yesmovies.to)
 - [FMOVIES](https://www3.fmovies.to/)
 - [openloadmovies.net](https://openloadmovies.net/) Reliable movie streaming site which uses OpenLoad
 - [HD MOVIES](https://hdm.to/) Another streaming site which uses OpenLoad
@@ -637,7 +716,6 @@ premium services
 - [xPau.se](http://xpau.se/)
 - [StreamCouch](https://www2.streamcouch.com/)
 - [Qwemovies](https://www3.qwemovies.com/)
-- [HDO](https://hdo.to/)
 - [#1 Movies Website](https://www1.1movies.is)
 
 ### Sports Streaming

--- a/readme.md
+++ b/readme.md
@@ -47,17 +47,17 @@
     - [Custom Google Search Engines](#custom-google-search-engines)
     - [FTP Indexers](#ftp-indexers)
     - [DDL Search Engines and Crawlers](#ddl-search-engines-and-crawlers)
-    - [DDL Link Sites](#normal-ddl-indexers)
+    - [DDL Link Sites](#ddl-link-sites)
     - [Premium Link Generators](#premium-link-generators)
     - [Premium Link Hosts](#premium-link-hosts)
     - [Open Directories](#open-directories)
-    - [Sports Streaming](#sports-streaming)
     - [Streaming Sites](#streaming-sites)
         - [HD Streaming](#hd-streaming)
         - [Big Media Libraries](#big-media-libraries)
         - [TV & Anime Streaming](#tv-and-anime-streaming)
+        - [Sports Streaming](#sports-streaming)
         - [Specialty Sites](#specialty-sites)
-        - [Openload Hosts](#openload-hosts)
+        - [Openload Hosts](#third-party-hosts)
         - [Uncategorized](#uncategorized)
 - [Media Centre Applications](#media-centre-applications)
     - [Stremio Addons](#stremio-addons)
@@ -612,7 +612,11 @@ premium services
 - [How To Stream Movies, TV, Anime & Sports Online](https://www.removeddit.com/r/FREEMEDIAFUCKYEAH/comments/8fwnxr/how_to_stream_movies_tv_anime_online/) :star2: Huge list by /u/nbatman
 
 #### HD Streaming
+- [Best Free Streaming](https://www.bestfreestreaming.com/) Site that rates streaming services
+- [/r/MovieStreamingSites](https://www.reddit.com/r/MovieStreamingSites/)
+- [/r/BestOfStreamingVideo](https://www.reddit.com/r/BestOfStreamingVideo/)
 - [HD MultiredditHD](https://www.reddit.com/user/nbatman/m/streaming2/)
+- [r/Megalinks](https://www.reddit.com/r/megalinks/) HD Movies/TV Shows hosted on mega site (DDL)
 - [StreamCR](https://scr.cr/)
 - [HDFlix](http://hdflix.net/)
 - [Yes! Movies](https://yesmovies.to)
@@ -625,8 +629,18 @@ premium services
 - [Spacemov](http://spacemov.io/)
 - [XMovies8](https://xmovies8.ru/)
 - [IWatchFlix](https://www.iwatchflix.xyz/)
-- [r/Megalinks](https://www.reddit.com/r/megalinks/)
 - [IceFilms](http://www.icefilms.info/)
+- [FlixGo](https://flixgo.net/)
+- [Movie123](http://movie123.club/)
+- [LookMovie](https://lookmovie.ag/)
+- [FilmXY](https://www.filmxy.one/)
+- [AZMovies](https://azmovies.xyz/)
+- [1Movies](http://1movies.nl)
+- [Rainierland](https://rainierland.is/)
+- [WatchFullMovie](http://watchfullmovie.co)
+- [FMOVIES](https://www3.fmovies.to/)
+- [HDOnline](https://www1.hdonline.eu)
+- [YMovies](https://ymovies.tv/) Streaming site full of YIFY and other releases
 
 #### Big Media Libraries
 - [Streaming Multireddit](https://www.reddit.com/user/nbatman/m/streaming/)
@@ -658,67 +672,8 @@ premium services
 - [Anime8](https://anime8.me/)
 - [NineAnime](https://www.nineanime.com/)
 
-#### Specialty Sites
-- [Einthusan](https://einthusan.tv/intro/) (Foreign)
-- [Dramago](http://www.dramago.com/)
-- [WatchAsian](https://www2.watchasian.co/) (Foreign)
-- [Layarkaca](http://layarkaca21.ru/) (Foreign)
-- [DramaCool](http://www1.dramacoolfirst.com/) (Foreign)
-- [KingsofHorror](https://www.youtube.com/user/TheKingsofHorror/) (Youtube Horror)
-- [MutantSorority](https://www.youtube.com/channel/UCWcF6KTn_sSSJ1AIj1bQmRg) (Youtube Horror)
-- [TromaMovies](https://www.youtube.com/channel/UC4O0LNYmaOczcSMHA_FE1Mw) (Youtube Horror)
-- [Film1k](http://www.film1k.com/la-bestia-uccide-a-sangue-freddo-1971.html) (Movies with nudity)
-- [Rulu](https://www.rulu.co/) (Youtube Red Series)
-- [Club MST3k](http://www.club-mst3k.com/) (Every episode of MST3K)
-- [Archive.org](https://archive.org/) (Old movies)
-
-#### Openload Hosts
-- [Ololo](https://ololo.to/)
-- [MovieZion](https://www.nicemoviezion.pro/)
-- [FMovies](https://www4.fmovies.se/)
-- [Vmovee](https://vmovee.me/)
-- [MovieJagg](https://www.coolmoviejagg.pro/)
-- [IWannaWatch](https://www.iwannawatch.is/)
-- [Solarmoviefreez](http://solarmoviefreez.com/)
-- [UWatchFree](https://www.uwatchfree.tv/)
-- [Oakmovies](http://oakmovies.com/)
-- [Vexmovies](http://vexmovies.org/)
-- [Openloadmovie](https://openloadmovie.ws/)
-
-#### Uncategorized
-- [cine.to](https://cine.to/)
-- [Movie123](http://movie123.club/)
-- [FlixGo](https://flixgo.net/)
-- [LookMovie](https://lookmovie.ag/)
-- [FilmXY](https://www.filmxy.one/)
-- [onemov](https://onemov.net/)
-- [AZMovies](https://azmovies.xyz/)
-- [1Movies](http://1movies.nl)
-- [Rainierland](https://rainierland.is/)
-- [WatchFullMovie](http://watchfullmovie.co)
-- [MegaShare](http://megashare9.su)
-- [cinebloom](https://www2.cinebloom.com)
-- [QQMovies](http://qqmovies.co)
-- [HDEUROPIX](https://topeuropix.net/)
-- [/r/MovieStreamingSites](https://www.reddit.com/r/MovieStreamingSites/)
-- [/r/BestOfStreamingVideo](https://www.reddit.com/r/BestOfStreamingVideo/)
-- [FMOVIES](https://www3.fmovies.to/)
-- [openloadmovies.net](https://openloadmovies.net/) Reliable movie streaming site which uses OpenLoad
-- [HD MOVIES](https://hdm.to/) Another streaming site which uses OpenLoad
-- [HDOnline](https://www1.hdonline.eu)
-- [YMovies](https://ymovies.tv/) Streaming site full of YIFY and other releases
-- [WatchFree](https://watchfree.at/)
-- [Daxiv Video](https://daxiv.com/) Movies & TV shows online or stream right to your smart TV, game console, PC, Mac, mobile, tablet and more. Primarily Chinese content.
-- [VodLocker](https://vodlocker.tv/)
-- [movies2k](http://www.movie2k.st)
-- [M4UFree.TV](http://m4ufree.tv/)
-- [Flixanity](https://flixanity.xyz/)
-- [xPau.se](http://xpau.se/)
-- [StreamCouch](https://www2.streamcouch.com/)
-- [Qwemovies](https://www3.qwemovies.com/)
-- [#1 Movies Website](https://www1.1movies.is)
-
-### Sports Streaming
+#### Sports Streaming
+- [Best Sport Streaming](https://www.bestsportstreaming.com/) Site that rates sport streaming services
 - [LiveTV](https://livesx.eu/)
 - [Cricfree](https://crickfree.org/)
 - [VIPBox](https://www.vipbox.live/) Spanish
@@ -738,6 +693,53 @@ premium services
 - [Send It](https://sendit.gg/) Live stream listings for sports, news, gaming, and more.
 - [SportsHD](http://www.speedsports.me)
 - [720pStream](http://www.720pstream.me/)
+
+#### Specialty Sites
+- [Einthusan](https://einthusan.tv/intro/) (Foreign)
+- [Dramago](http://www.dramago.com/)
+- [WatchAsian](https://www2.watchasian.co/) (Foreign)
+- [Layarkaca](http://layarkaca21.ru/) (Foreign)
+- [DramaCool](http://www1.dramacoolfirst.com/) (Foreign)
+- [KingsofHorror](https://www.youtube.com/user/TheKingsofHorror/) (Youtube Horror)
+- [MutantSorority](https://www.youtube.com/channel/UCWcF6KTn_sSSJ1AIj1bQmRg) (Youtube Horror)
+- [TromaMovies](https://www.youtube.com/channel/UC4O0LNYmaOczcSMHA_FE1Mw) (Youtube Horror)
+- [Film1k](http://www.film1k.com/la-bestia-uccide-a-sangue-freddo-1971.html) (Movies with nudity)
+- [Rulu](https://www.rulu.co/) (Youtube Red Series)
+- [Club MST3k](http://www.club-mst3k.com/) (Every episode of MST3K)
+- [Archive.org](https://archive.org/) (Old movies)
+
+#### Third Party Hosts
+- [Ololo](https://ololo.to/)
+- [MovieZion](https://www.nicemoviezion.pro/)
+- [FMovies](https://www4.fmovies.se/)
+- [Vmovee](https://vmovee.me/)
+- [MovieJagg](https://www.coolmoviejagg.pro/)
+- [IWannaWatch](https://www.iwannawatch.is/)
+- [Solarmoviefreez](http://solarmoviefreez.com/)
+- [UWatchFree](https://www.uwatchfree.tv/)
+- [Oakmovies](http://oakmovies.com/)
+- [Vexmovies](http://vexmovies.org/)
+- [Openloadmovie](https://openloadmovie.ws/)
+- [cine.to](https://cine.to/)
+- [cinebloom](https://www2.cinebloom.com)
+- [QQMovies](http://qqmovies.co)
+- [HDEUROPIX](https://topeuropix.net/)
+- [openloadmovies.net](https://openloadmovies.net/) Reliable movie streaming site which uses OpenLoad
+- [HD MOVIES](https://hdm.to/) Another streaming site which uses OpenLoad
+- [VodLocker](https://vodlocker.tv/)
+- [StreamCouch](https://www2.streamcouch.com/)
+- [Qwemovies](https://www3.qwemovies.com/) OpenLoad
+
+#### Uncategorized
+- [onemov](https://onemov.net/)
+- [MegaShare](http://megashare9.su)
+- [WatchFree](https://watchfree.at/)
+- [Daxiv Video](https://daxiv.com/) Movies & TV shows online or stream right to your smart TV, game console, PC, Mac, mobile, tablet and more. Primarily Chinese content.
+- [movies2k](http://www.movie2k.st)
+- [M4UFree.TV](http://m4ufree.tv/)
+- [Flixanity](https://flixanity.xyz/)
+- [xPau.se](http://xpau.se/)
+- [#1 Movies Website](https://www1.1movies.is)
 
 ## Media Centre Applications
 - [Plex](https://www.plex.tv/) :star2: Your content—from live and recorded TV and personal media, to on-demand web shows, video news, and podcasts—beautifully organized and ready to stream everywhere.


### PR DESCRIPTION
Fixed Streaming Category

Changes: 
- Added /u/nbatman's list.
- Changed /u/nbatman link to remove reddit link since comment is deleted, we could always just remove it all together since the list has been transferred over.
- Removed some sites that I knew off the top of my head that have shut down (pron.tv/alluc.ee)
- Added Alternate Sites (Alluc.uno)
- Added Subcategories that match /u/nbatman's
- Temporarily moved all other previous streaming sites in uncategorized category, will put in subcategories once I test each site, new sites added could go in this category or until we figure out the correct subcategory for it.

Important:
- Haven't checked yet if all sites work.
- Can't see any typos from my view, let me know if anyone sees anything.
- Let me know what I should change if you don't like this current change.