### PR TITLE
Fix Movies "R" Us hyperlink issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -591,7 +591,7 @@ ltConfig is a plugin for Deluge that allows direct modification to libtorrent se
 - [DirtyWarez Forum](https://forum.dirtywarez.com/) Popular warez forum with films, TV shows, ebooks, anime, games, and more
 - [snahp.it](https://snahp.it/) :star2: replaced /r/megalinks
 - [hdencode](https://hdencode.com/)
-- [Movies "R" Us](moviesrus.tk) The newest movies in 1080p. Available with DDL through MediaFire and streaming through AnonFile.
+- [Movies "R" Us](https://moviesrus.tk) The newest movies in 1080p. Available with DDL through MediaFire and streaming through AnonFile.
 - [Movie Glide](https://www.movieglide.com/)
 - [Release BB](http://rlsbb.ru)
 - [DDLValley](https://www.ddlvalley.me/) DDL links for Movies, Games, Tv Shows, Apps, Ebooks and Music.


### PR DESCRIPTION
So I was just wondering around the repo and then I noticed that when I clicked on Movies "R" Us, It redirected me to 404 error github page. So I took a look at the readme.md and found out that it was caused because there was no `https://` before the website address and so, github thought that there is file called `movierus.tk` in the repo which, of course, does not exist and is the culprit of that issue.

I have thought about opening an issue in github regarding it. But, I think I would be more helpful if I made the solution just a single click ;)