### PR TITLE
Removing Terrarium TV app from the list

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -1241,7 +1241,6 @@
 </DL></p>
 <DT><H3>Streaming Apps</H3>
 <DL><p>
-<DT><A HREF="https://www.reddit.com/r/TTVreborn/comments/9n7zsf/terrariumtv_v6_mod_balatan/">TerrariumTV</A>
 <DT><A HREF="https://www.kokotime.tv/">Kokotime</A>
 <DT><A HREF="https://forum.mobilism.org/viewtopic.php?f=429&t=2720792&hilit=mobdro">Mobdro</A>
 <DT><A HREF="https://forum.mobilism.org/viewtopic.php?t=2786441">Cinema</A>

--- a/readme.html
+++ b/readme.html
@@ -3212,8 +3212,6 @@ premium services</li>
 <a id="user-content-streaming-apps" class="anchor" href="#streaming-apps" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Streaming Apps</h3>
 <ul>
 <li>
-<a href="https://www.reddit.com/r/TTVreborn/comments/9n7zsf/terrariumtv_v6_mod_balatan/" rel="nofollow">TerrariumTV</a> <g-emoji class="g-emoji" alias="star2" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f31f.png">🌟</g-emoji> V6 of this newly-fixed app for streaming TV and film. Features Trakt.tv and Real-Debrid integration</li>
-<li>
 <a href="https://www.kokotime.tv/" rel="nofollow">Kokotime</a> Kokotime is an addon-based, simple, free and elegantly designed app that will let you watch all your favorite media content in a unique and elegant user-friendly design</li>
 <li>
 <a href="https://forum.mobilism.org/viewtopic.php?f=429&amp;t=2720792&amp;hilit=mobdro" rel="nofollow">Mobdro</a> Mobdro constantly searches the web for the best free video streams and brings them to your device.</li>

--- a/readme.md
+++ b/readme.md
@@ -1289,7 +1289,6 @@ premium services
 - [YouTube Vanced](https://vanced.app/) Vanced is a well known modded version of YouTube with many features such as adblocking and background playback and many more.
 
 ### Streaming Apps
-- [TerrariumTV](https://www.reddit.com/r/TTVreborn/comments/9n7zsf/terrariumtv_v6_mod_balatan/) :star2: V6 of this newly-fixed app for streaming TV and film. Features Trakt.tv and Real-Debrid integration
 - [Kokotime](https://www.kokotime.tv/) Kokotime is an addon-based, simple, free and elegantly designed app that will let you watch all your favorite media content in a unique and elegant user-friendly design
 - [Mobdro](https://forum.mobilism.org/viewtopic.php?f=429&t=2720792&hilit=mobdro) Mobdro constantly searches the web for the best free video streams and brings them to your device.
 - [Cinema](https://forum.mobilism.org/viewtopic.php?t=2786441) a lot of Movies & TV/Shows to watch and download.


### PR DESCRIPTION
Terrarium TV app has been shut down and discontinued (see its [official website](https://terrariumtv.com) for more information). The code is outdated and almost all scrapers are not working now. There are many better alternatives out there. Terrarium TV shouldn't be listed here anymore.