### PR TITLE
Change libgen url to a working one

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1135,7 +1135,7 @@ premium services
 - [MagazineLib](https://magazinelib.com/) Free PDF and interactive e-magazines
 
 ## Academic Papers and Material
-- [LibGen](http://gen.lib.rus.ec/http://gen.lib.rus.ec/) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
+- [LibGen](http://gen.lib.rus.ec/) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
 - [Sci-Hub](https://sci-hub.tw/) the first pirate website in the world to provide mass and public access to tens of millions of research papers
 - [BookSC](http://booksc.org/) The world's largest scientific articles store. 50,000,000+ articles for free.
 - [Academic Torrents](http://academictorrents.com/) A Community-Maintained Distributed Repository for researchers, by researchers. Making 32.66TB of research data available!

--- a/readme.md
+++ b/readme.md
@@ -1135,7 +1135,7 @@ premium services
 - [MagazineLib](https://magazinelib.com/) Free PDF and interactive e-magazines
 
 ## Academic Papers and Material
-- [LibGen](http://gen.lib.rus.ec/https://github.com/Igglybuff/awesome-piracy/pull/220) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
+- [LibGen](http://gen.lib.rus.ec/http://gen.lib.rus.ec/) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
 - [Sci-Hub](https://sci-hub.tw/) the first pirate website in the world to provide mass and public access to tens of millions of research papers
 - [BookSC](http://booksc.org/) The world's largest scientific articles store. 50,000,000+ articles for free.
 - [Academic Torrents](http://academictorrents.com/) A Community-Maintained Distributed Repository for researchers, by researchers. Making 32.66TB of research data available!

--- a/readme.md
+++ b/readme.md
@@ -1135,7 +1135,7 @@ premium services
 - [MagazineLib](https://magazinelib.com/) Free PDF and interactive e-magazines
 
 ## Academic Papers and Material
-- [LibGen](http://libgen.io/) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
+- [LibGen](http://gen.lib.rus.ec/https://github.com/Igglybuff/awesome-piracy/pull/220) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
 - [Sci-Hub](https://sci-hub.tw/) the first pirate website in the world to provide mass and public access to tens of millions of research papers
 - [BookSC](http://booksc.org/) The world's largest scientific articles store. 50,000,000+ articles for free.
 - [Academic Torrents](http://academictorrents.com/) A Community-Maintained Distributed Repository for researchers, by researchers. Making 32.66TB of research data available!


### PR DESCRIPTION
There is already a pull request to change libgen url (#220), but that url throws me a certificate error. This one doesn't. 