### PR TITLE
Update YggTorrent link

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -247,7 +247,7 @@
 <DT><A HREF="https://www.torlock.com/">Torlock</A>
 <DT><A HREF="https://www.digbt.org/">DIGBT</A>
 <DT><A HREF="https://www.torrent9.ph/">Torrent9</A>
-<DT><A HREF="https://www3.yggtorrent.to/">YggTorrent</A>
+<DT><A HREF="https://yggtorrent.se/">YggTorrent</A>
 <DT><A HREF="https://worldwidetorrents.me/">WorldWide Torrents</A>
 </DL></p>
 <DT><H3>Tracker Aggregators</H3>

--- a/readme.html
+++ b/readme.html
@@ -1414,7 +1414,7 @@ for any IP address.</li>
 <li>
 <a href="https://www.torrent9.ph/" rel="nofollow">Torrent9</a> French torrent search engine</li>
 <li>
-<a href="https://www3.yggtorrent.to/" rel="nofollow">YggTorrent</a> French tracker and search engine (have a download/upload ratio limitation)</li>
+<a href="https://yggtorrent.se/" rel="nofollow">YggTorrent</a> French tracker and search engine (have a download/upload ratio limitation)</li>
 <li>
 <a href="https://worldwidetorrents.me/" rel="nofollow">WorldWide Torrents</a> Another public tracker with a reasonably nice UI</li>
 </ul>

--- a/readme.md
+++ b/readme.md
@@ -383,6 +383,7 @@ for any IP address.
 - [DIGBT](https://www.digbt.org/) DIGBT is a DHT torrent search engine.
 - [Torrent9](https://www.torrent9.ph/) French torrent search engine
 - [YggTorrent](https://www3.yggtorrent.to/) French tracker and search engine (have a download/upload ratio limitation)
+- [YggTorrent](https://yggtorrent.se/) French tracker and search engine (have a download/upload ratio limitation)
 - [WorldWide Torrents](https://worldwidetorrents.me/) Another public tracker with a reasonably nice UI
 - [Rock Box](https://rawkbawx.rocks/) Metal music tracker
 - [Music Torrent](http://music-torrent.net) General music tracker


### PR DESCRIPTION
YggTorrent's website is now https://yggtorrent.ws.
They change domains a lot to bypass Google's blocking. The up-to-date domain con be found at https://twitter.com/yggtorrent_com