### PR TITLE
add hola proxy standalone client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1570,6 +1570,7 @@ premium services
 - [PiracyArchive](https://github.com/nid666/PiracyArchive) A complete backup of the Reddit /r/Piracy subreddit
 - [List of warez groups](https://en.wikipedia.org/wiki/List_of_warez_groups) Wikipedia's list of warez groups and individuals.
 - [netflix-proxy](https://github.com/ab77/netflix-proxy/) Smart DNS proxy to watch Netflix out-of-region
+- [hola-proxy](https://github.com/Snawoot/hola-proxy) Standalone Hola proxy client. Allows access via residental proxies as well.
 - [k8s-usenet](https://github.com/aldoborrero/k8s-usenet) A collection of Helm (Kubernetes) charts related to different Usenet services (sabnzbd, radarr, sonarr...).
 
 ## Contribute


### PR DESCRIPTION
Might be useful as a generic free proxy or a solution for steaming services access.