### PR TITLE
Add Posteo to Email

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,7 @@ You will notice some items on this list have a :star2: next to them. Items with 
 - [10 Minute Mail](https://10minutemail.net/) Disposable, private mailboxes
 - [Cock.li](https://cock.li/) Yeah it's mail with cocks
 - [Tutanota](https://tutanota.com/) Secure, open source email service
+- [Posteo](https://posteo.de) Email service focused on security, privacy, and sustainability
 
 ## Decentralised Networks
 - [Tor](https://www.torproject.org/) :star2: Tor is free software and an open network that helps you defend against traffic analysis.


### PR DESCRIPTION
[Posteo](https://posteo.de) is an email service focused on [security](https://posteo.de/en/site/encryption), [privacy](https://posteo.de/en/site/privacy), and [sustainability](https://posteo.de/en/site/sustainability). That phrase is taken from their [about](https://posteo.de/en/site/about_posteo) page.

You can find some decently objective information about them from the third-party thatoneprivacysite.net:

[Simple Email Comparison](https://thatoneprivacysite.net/email-comparison/#simple-email-comparison)
[Detailed Email Comparison](https://thatoneprivacysite.net/email-comparison/#detailed-email-comparison)