### PR TITLE
tparser.org is dead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -391,7 +391,6 @@ for any IP address.
 
 ### Tracker Aggregators
 - [snowfl](https://snowfl.com/) snowfl is a torrent aggregator which searches various public torrent indexes in real-time
-- [TParser](http://tparser.org/) Russian torrent sites indexer
 - [Torrents.me](https://torrents.me/) Torrents.me combines popular torrent sites and specialized private trackers in a torrent multisearch.
 - [rats-search](https://github.com/DEgITx/rats-search) P2P Bittorrent search engine
 - [AIO Search](http://www.aiosearch.com/) Torrent search engine


### PR DESCRIPTION
The site seems to be down for a long time now (more than a year).
It had a mirror **tparser.me** which is also down for a long time now. Then there was kind of a clone **Riptide.cz** that is also down.
All those sites either not available or redirect to some scamming/phishing sites.