### PR TITLE
Scihub domain name update : sci-hub.se

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1143,7 +1143,7 @@ premium services
 
 ## Academic Papers and Material
 - [LibGen](https://libgen.is/) search engine for articles and books on various topics, which allows free access to content that is otherwise paywalled or not digitized elsewhere
-- [Sci-Hub](https://sci-hub.tw/) the first pirate website in the world to provide mass and public access to tens of millions of research papers
+- [Sci-Hub](https://sci-hub.se/) the first pirate website in the world to provide mass and public access to tens of millions of research papers
 - [BookSC](http://booksc.org/) The world's largest scientific articles store. 50,000,000+ articles for free.
 - [Academic Torrents](http://academictorrents.com/) A Community-Maintained Distributed Repository for researchers, by researchers. Making 32.66TB of research data available!
 


### PR DESCRIPTION
.tw is now non existent domain.