### PR TITLE
Remove Windows 10 Privacy Guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,7 +247,6 @@ You will notice some items on this list have a :star2: next to them. Items with 
 
 ### Windows 10 Privacy
 - [O&O ShutUp10](https://www.oo-software.com/en/shutup10) O&O ShutUp10 means you have full control over which comfort functions under Windows 10 you wish to use, and you decide when the passing on of your data goes too far.
-- [Windows 10 Privacy Guide](https://github.com/adolfintel/Windows10-Privacy) :star2: an In-depth guide on purging Windows 10 of Microsoft's attempts to track you
 - [Windows Privacy Tweaker](https://www.phrozen.io/freeware/windows-privacy-tweaker/) Freeware app from phrozen.io
 - [Winaero](https://winaero.com/blog/about-us/) Free, small and useful software for Windows.
 - [WPD](https://wpd.app/) The real privacy dashboard for Windows


### PR DESCRIPTION
The Windows 10 Privacy Guide has been abandoned due to the creator's switch to Linux, and has only been updated for the 1903 update. Because of this, it should be removed.