### PR TITLE
Remove HorribleSubs fansub from anime

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -765,7 +765,6 @@ premium services
 - [anime-sharing](http://www.anime-sharing.com/forum/) Forum for sharing anime
 - [AniDex](https://anidex.info) Torrent tracker and indexer, primarily for English fansub groups of anime
 - [animeEncodes](https://www.animencodes.com/)
-- [HorribleSubs](https://horriblesubs.info/) Download anime via torrent files, magnet links, XDCC, and premium link hosts.
 - [Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
 - [AnimeOut](https://www.animeout.xyz/) Over 1000's of Encoded Anime with DDL links.
 - [Kissanime.ac](https://kissanime.ac/) Large cartoon collection, uses RapidVideo/Openload


### PR DESCRIPTION
HorribleSubs officially said farewell after finishing summer 2020 season (See https://horriblesubs.info/)