### PR TITLE
Removes the original Plex Requests link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -903,7 +903,6 @@ premium services
 
 ### Plex Requests
 - [Ombi](http://ombi.io/) :star2: Want a Movie or TV Show on Plex or Emby? Use Ombi!
-- [Plex Requests](http://plexrequests.8bits.ca/) Simple automated way for users to request new content for Plex
 - [plexrequests-meteor](https://github.com/lokenx/plexrequests-meteor) Meteor version of the original Plex Requests
 - [Mellow](https://github.com/v0idp/Mellow/) Bot which can communicate with several APIs like Ombi, Sonarr, Radarr and Tautulli which are related to home streaming. Based off of node:9.3
 - [MediaButler](https://github.com/physk/MediaButler) Discord bot for use with PleX and several other apps that work with it.


### PR DESCRIPTION
http://plexrequests.8bits.ca/

Removing it from the list as it's dead and pretty deprecated at this point anyway.