### PR TITLE
Changes the link of 'PDF/Ebook trackers for college textbooks'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1139,7 +1139,7 @@ premium services
 ## Textbooks
 - [All IT eBooks](http://www.allitebooks.com/) A big database of free, direct links for IT and programming ebooks
 - [it-ebooks](http://it-ebooks.info) Large selection of free and open-source IT ebooks
-- [PDF/Ebook trackers for college textbooks](https://www.reddit.com/r/trackers/comments/hrgmv/tracker_with_pdfsebooks_of_college_textbooks/c1xrq44/) Old-but-still-useful list of ebook/textbook trackers, DDL sites, and IRC communities
+- [PDF/Ebook trackers for college textbooks](https://archive.fo/7kCYY) Old-but-still-useful list of ebook/textbook trackers, DDL sites, and IRC communities
 - [How to "rent" your textbooks for free from Amazon](https://www.reddit.com/r/Piracy/comments/3ma9qe/guide_how_to_rent_your_textbooks_for_free_from/) "Going to college? Living off top ramen for dinner? Let me show you have to "rent" your textbooks for free & for life!"
 - [Guide for Finding Textbooks](https://www.reddit.com/r/Piracy/comments/3i9y7n/guide_for_finding_textbooks/) Extensive tutorial by /u/Amosqu
 - [forcoder](https://forcoder.su/) Ebooks & Elearning For Programming


### PR DESCRIPTION
The old link does not have any link to pirated sites. Thus a backup link is Added. Fixes #350.