### PR TITLE
xip.io is nxdomain

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,8 +271,6 @@ You will notice some items on this list have a :star2: next to them. Items with 
 
 ## Domain Names
 - [Njalla](https://njal.la/) a privacy-aware domain registration service
-- [xip.io](http://xip.io/) magic domain name that provides wildcard DNS
-for any IP address.
 - [Domainr](https://domainr.com/) Domainr finds domain names and short URLs. Instantly check availability and register for all top-level domains.
 
 ## Torrenting


### PR DESCRIPTION
xip.io is NXDOMAIN as I checked on the https://dnschecker.org/#A/xip.io .