### PR TITLE
Removed Universal Bypass extension due to broken link

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -50,7 +50,6 @@
 <DT><A HREF="https://addons.mozilla.org/en-US/firefox/addon/noscript/">NoScript</A>
 <DT><A HREF="https://chrome.google.com/webstore/detail/outline-read-without-clut/daoolpmoieinofbnddaofhkhmbagfmnj">Outline</A>
 <DT><A HREF="https://burles.co/en/">Burlesco</A>
-<DT><A HREF="https://chrome.google.com/webstore/detail/universal-bypass/aihomhdbhpnpmcnnbckjjcebjoikpihj">Universal Bypass</A>
 <DT><A HREF="https://violentmonkey.github.io/">Violentmonkey</A>
 <DT><A HREF="https://github.com/nextgens/anti-paywall">Anti-Paywall</A>
 <DT><A HREF="https://github.com/Ibit-to/google-unlocked">Google Unlocked</A>

--- a/readme.html
+++ b/readme.html
@@ -1043,8 +1043,6 @@ pre {
 <li>
 <a href="https://burles.co/en/" rel="nofollow">Burlesco</a> Read news without subscribing, bypass the paywall</li>
 <li>
-<a href="https://chrome.google.com/webstore/detail/universal-bypass/aihomhdbhpnpmcnnbckjjcebjoikpihj" rel="nofollow">Universal Bypass</a> Universal Bypass automatically skips annoying link shorteners.</li>
-<li>
 <a href="https://violentmonkey.github.io/" rel="nofollow">Violentmonkey</a> An open source userscript manager.</li>
 <li>
 <a href="https://github.com/nextgens/anti-paywall">Anti-Paywall</a> A browser extension that maximizes the chances of bypassing paywalls</li>

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,6 @@ You will notice some items on this list have a :star2: next to them. Items with 
 - [ScriptSafe](https://chrome.google.com/webstore/detail/scriptsafe/oiigbmnaadbkfbmpbfijlflahbdbdgdf?hl=en) A browser extension that gives users control of the web and more secure browsing while emphasizing simplicity and intuitiveness.
 - [NoScript](https://noscript.net/getit) Allow active content to run only from sites you trust, and protect yourself against XSS and clickjacking attacks. Firefox only.
 - [Burlesco](https://burles.co/en/) Read the news without subscribing, bypass the paywall
-- [Universal Bypass](https://github.com/Sainan/Universal-Bypass) Universal Bypass automatically skips annoying link shorteners.
 - [Violentmonkey](https://violentmonkey.github.io/) An open-source userscript manager.
 - [Anti-Paywall](https://github.com/nextgens/anti-paywall) A browser extension that maximizes the chances of bypassing paywalls
 - [Google Unlocked](https://github.com/Ibit-to/google-unlocked) Uncensor google search results.


### PR DESCRIPTION
Removed the Universal Bypass browser extension from Readme and bookmark file due to broken link.
Project has been removed from GitHub as well as from chrome store.