### PR TITLE
Added Zspotify

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -991,6 +991,7 @@
 <DT><A HREF="https://jwallet.github.io/spy-spotify/">Spytify</A>
 <DT><A HREF="https://forum.mobilism.org/viewtopic.php?f=1332&t=2950704">Spotify modded APK</A>
 <DT><A HREF="https://github.com/Superhackman/downtify-premium">Downtify</A>
+<DT><A HREF="https://github.com/jsavargas/zspotify">Zspotify - Download Spotify songs without Premium </A>
 </DL></p>
 <DT><H3>iTunes</H3>
 <DL><p>


### PR DESCRIPTION
Added zspotify. 

Repository contains a python script that allows the download of spotify urls.  Can be used to download playlists and liked songs too.

A docker image is also provided.

It seems that the original repository has been taken down however this fork is working.