### PR TITLE
Add abelmorad

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -870,6 +870,7 @@
 <DT><H3>Repacks</H3>
 <DL><p>
 <DT><A HREF="http://fitgirl-repacks.site/">FitGirl Repacks</A>
+<DT><A HREF="https://dodi-repacks.site/">Dodi Repacks</A>
 <DT><A HREF="https://xatab-repack.net">Xatab Repacks</A>
 <DT><A HREF="https://www.elamigos-games.com/">ElAmigos Games</A>
 <DT><A HREF="http://qoob.name/">qoob.name</A>

--- a/readme.md
+++ b/readme.md
@@ -761,7 +761,6 @@ premium services
 - [animeEncodes](https://www.animencodes.com/)
 - [Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
 - [AnimeOut](https://www.animeout.xyz/) Over 1000's of Encoded Anime with DDL links.
-- [4anime](https://4anime.to/) A relatively new site the might become the new Masterani.me. Clean interface.
 - [AnimeRam](https://ww2.animeram.cc/) A streaming website for dubbed/subbed anime.
 - [animepahe](https://animepahe.com/) A minimilistic anime streaming/download website, subs only.
 

--- a/readme.md
+++ b/readme.md
@@ -761,7 +761,6 @@ premium services
 - [animeEncodes](https://www.animencodes.com/)
 - [Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
 - [AnimeOut](https://www.animeout.xyz/) Over 1000's of Encoded Anime with DDL links.
-- [AnimeRam](https://ww2.animeram.cc/) A streaming website for dubbed/subbed anime.
 - [animepahe](https://animepahe.com/) A minimilistic anime streaming/download website, subs only.
 
 #### Cartoons

--- a/readme.md
+++ b/readme.md
@@ -759,7 +759,6 @@ premium services
 - [anime-sharing](http://www.anime-sharing.com/forum/) Forum for sharing anime
 - [AniDex](https://anidex.info) Torrent tracker and indexer, primarily for English fansub groups of anime
 - [animeEncodes](https://www.animencodes.com/)
-- [Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
 - [AnimeOut](https://www.animeout.xyz/) Over 1000's of Encoded Anime with DDL links.
 - [animepahe](https://animepahe.com/) A minimilistic anime streaming/download website, subs only.
 

--- a/readme.md
+++ b/readme.md
@@ -983,6 +983,7 @@ premium services
 
 ### Repacks
 - [FitGirl Repacks](http://fitgirl-repacks.site/) :star2: Popular DDL and torrent site for game repacks
+- [Dodi Repacks](https://dodi-repacks.site/) 💯: An Awesome game repacker! 
 - [Xatab Repacks](https://xatab-repack.net) Russian game repacker, primarily torrents
 - [ElAmigos Games](https://www.elamigos-games.com/) Premium links to cracked games
 - [qoob.name](http://qoob.name/) Repacker site

--- a/readme.md
+++ b/readme.md
@@ -761,7 +761,6 @@ premium services
 - [animeEncodes](https://www.animencodes.com/)
 - [Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
 - [AnimeOut](https://www.animeout.xyz/) Over 1000's of Encoded Anime with DDL links.
-- [Kissanime.ac](https://kissanime.ac/) Large cartoon collection, uses RapidVideo/Openload
 - [4anime](https://4anime.to/) A relatively new site the might become the new Masterani.me. Clean interface.
 - [AnimeRam](https://ww2.animeram.cc/) A streaming website for dubbed/subbed anime.
 - [animepahe](https://animepahe.com/) A minimilistic anime streaming/download website, subs only.

--- a/readme.md
+++ b/readme.md
@@ -762,7 +762,6 @@ premium services
 - [Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
 - [AnimeOut](https://www.animeout.xyz/) Over 1000's of Encoded Anime with DDL links.
 - [Kissanime.ac](https://kissanime.ac/) Large cartoon collection, uses RapidVideo/Openload
-- [Anime8](https://anime8.me/) Basic streaming site layout, large collection of anime shows
 - [4anime](https://4anime.to/) A relatively new site the might become the new Masterani.me. Clean interface.
 - [AnimeRam](https://ww2.animeram.cc/) A streaming website for dubbed/subbed anime.
 - [animepahe](https://animepahe.com/) A minimilistic anime streaming/download website, subs only.


### PR DESCRIPTION
removed these links because they are not working anymore

[Anime Twist](https://twist.moe/) An anime direct streaming site with a decent UI and video player
[Kissanime.ac](https://kissanime.ac/) Large cartoon collection, uses RapidVideo/Openload
[Anime8](https://anime8.me/) Basic streaming site layout, large collection of anime shows
[4anime](https://4anime.to/) A relatively new site the might become the new Masterani.me. Clean interface.
[AnimeRam](https://ww2.animeram.cc/) A streaming website for dubbed/subbed anime.